### PR TITLE
[BUGFIX] There can be more than one meta tag with http-equiv

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -555,7 +555,7 @@ class CleanHtmlService implements \TYPO3\CMS\Core\SingletonInterface {
 	public function includeHeaderComment(&$html) {
 		if (!empty($this->headerComment)) {
 			$html = preg_replace_callback(
-				'/<meta http-equiv(.*)>/Usi',
+				'/<base (.*)>/Usi',
 				function ($matches) {
 					return trim($matches[0] . $this->newline . $this->tab . $this->tab . '<!-- ' . $this->headerComment . '-->');
 				},


### PR DESCRIPTION
Better solution is the base tag! There should only be one on each page ...
Otherwise headerComent is rendered multiple times.