### PR TITLE
[BUGFIX] removeGenerator not working

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -544,7 +544,7 @@ class CleanHtmlService implements \TYPO3\CMS\Core\SingletonInterface {
 	 * @return void
 	 */
 	public function removeGenerator(&$html) {
-		preg_replace('/<meta name=\"?generator\"?.+?>/is', '', $html);
+		$html = preg_replace('/<meta name=\"?generator\"?.+?>/is', '', $html);
 	}
 
 	/**


### PR DESCRIPTION
Otherwise $html is not updated. I Got this Problem witrh PHP 5.5.21 and my bugfix solves it.