### PR TITLE
[BUGFIX] $config['enabled'] does not work in setVariables

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -95,10 +95,6 @@ class CleanHtmlService implements \TYPO3\CMS\Core\SingletonInterface {
 		}
 
 		if (!empty($config)) {
-			if ((bool) $config['enabled'] === FALSE) {
-				return;
-			}
-
 			if ($config['formatHtml'] && is_numeric($config['formatHtml'])) {
 				$this->formatType = (int) $config['formatHtml'];
 			}
@@ -147,6 +143,10 @@ class CleanHtmlService implements \TYPO3\CMS\Core\SingletonInterface {
 	 */
 	public function clean(&$html, $config = array()) {
 		if (!empty($config)) {
+			if ((bool) $config['enabled'] === FALSE) {
+				return;
+			}
+			
 			$this->setVariables($config);
 		}
 


### PR DESCRIPTION
On PHP 5.5.21 and TYPO3 6.2.11 $config['enabled'] only works in clean().