### PR TITLE
[BUGFIX] Only add header comment once

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -555,11 +555,12 @@ class CleanHtmlService implements \TYPO3\CMS\Core\SingletonInterface {
 	public function includeHeaderComment(&$html) {
 		if (!empty($this->headerComment)) {
 			$html = preg_replace_callback(
-				'/<base (.*)>/Usi',
+				'/<meta http-equiv(.*)>/Usi',
 				function ($matches) {
 					return trim($matches[0] . $this->newline . $this->tab . $this->tab . '<!-- ' . $this->headerComment . '-->');
 				},
-				$html
+				$html,
+				1
 			);
 		}
 	}


### PR DESCRIPTION
Current webdevelopments don't use the <base> url
but use the absRefPrefix setting

Related: #63108