### PR TITLE
[FEATURE] Support Google PageSpeed "exclude" comments

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -30,6 +30,9 @@ config.sourceopt {
 		# google search appliance
 		101 = /^googleoff_/usi
 		102 = /^googleon_/usi
+		
+		# Google pagespeed
+		104 = /^gps(e|s)/usi
 
 		# for typo-search
 		10 = {$sourceopt.removeComments.keep.10}


### PR DESCRIPTION
Keep the following two comments per default:
<!-- gpss -->
<!-- gpse -->