### PR TITLE
Improve TYPO3 9.5 LTS support

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -6,6 +6,7 @@ use HTML\Sourceopt\Manipulation\ManipulationInterface;
 use HTML\Sourceopt\Manipulation\RemoveBlurScript;
 use HTML\Sourceopt\Manipulation\RemoveComments;
 use HTML\Sourceopt\Manipulation\RemoveGenerator;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -66,12 +67,11 @@ class CleanHtmlService implements SingletonInterface
      */
     public function setVariables(array $config)
     {
-        switch (TYPO3_OS) { // set newline
-            case 'WIN':
-                $this->newline = "\r\n";
-                break;
-            default:
-                $this->newline = "\n";
+        // Set newline based on OS
+        if (Environment::isWindows()) {
+            $this->newline = "\r\n";
+        } else {
+            $this->newline = "\n";
         }
 
         if (!empty($config)) {
@@ -421,7 +421,7 @@ class CleanHtmlService implements SingletonInterface
     {
         $html = str_replace("\t", "", $html);
         // convert newlines according to the current OS
-        if (TYPO3_OS == "WIN") {
+        if (Environment::isWindows()) {
             $html = str_replace("\n", "\r\n", $html);
         } else {
             $html = str_replace("\r\n", "\n", $html);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('TYPO3_MODE')) {
+    die('Access denied.');
+}
+
+// Add static template configuration
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'sourceopt',
+    'Configuration/TypoScript',
+    'Sourceopt'
+);

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 [![Build Status](https://travis-ci.org/lochmueller/sourceopt.svg?branch=master)](https://travis-ci.org/lochmueller/sourceopt)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/lochmueller/sourceopt/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/lochmueller/sourceopt/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/lochmueller/sourceopt/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/lochmueller/sourceopt/?branch=master)
+
+You can find the documentation [here](https://docs.typo3.org/typo3cms/extensions/sourceopt/).

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   },
   "require": {
-    "php": ">=7.1.0",
-    "typo3/cms-core": "~8.7.0 || ~9.5.0 || dev-master"
+    "php": ">=7.2.0",
+    "typo3/cms-core": "~9.5.0 || dev-master"
   },
   "replace": {
     "sourceopt": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   },
   "require": {
-    "php": ">=5.6.0",
-    "typo3/cms-core": "~8.7.0||~9.4.0||~9.5.0||dev-master"
+    "php": ">=7.1.0",
+    "typo3/cms-core": "~8.7.0 || ~9.5.0 || dev-master"
   },
   "replace": {
     "sourceopt": "self.version",
@@ -36,7 +36,6 @@
   },
   "extra": {
     "typo3/cms": {
-      "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web",
       "Package": {
         "partOfMinimalUsableSystem": true

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,12 +9,10 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Dr. Ronald P. Steiner, Boris Nicolai, Tim Lochmueller',
     'author_email' => 'ronald.steiner@googlemail.com, boris.nicolai@andavida.com, tim@fruit-lab.de',
     'author_company' => null,
-    'constraints' =>
-        [
-            'depends' =>
-                [
-                    'typo3' => '8.7.0-9.5.99',
-                    'php' => '5.6.0-0.0.0',
-                ],
+    'constraints' =>[
+        'depends' => [
+            'typo3' => '8.7.0 - 9.5.99',
+            'php' => '7.2',
         ],
+    ],
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => null,
     'constraints' =>[
         'depends' => [
-            'typo3' => '8.7.0 - 9.5.99',
+            'typo3' => '9.5.0 - 9.5.99',
             'php' => '7.2',
         ],
     ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,7 +1,0 @@
-<?php
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
-
-// Add static template configuration
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Sourceopt');


### PR DESCRIPTION
This request improves the compatibility with TYPO3 9.5 LTS but also drop support for older versions and that's why this probably should be tagged as 2.0
I'm currently also working on a middleware instead of using hooks, but it looks like, that this is currently not possible with the same functionality as before. If you are interested, check out [this branch](https://github.com/runepiper/sourceopt/tree/feature/use-middleware).