### PR TITLE
Fix Bug that removes JS and CSS

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -194,6 +194,11 @@ class CleanHtmlService implements SingletonInterface
         );
 
         if ($htmlArrayTemp === false) {
+            // Restore saved comments, styles and java-scripts
+            for ($i = 0; $i < count($noFormat); $i++) {
+                $noFormat[$i] = $this->rTrimLines($noFormat[$i]); // remove white space after line ending
+                $html = str_replace("<!-- ELEMENT $i -->", $noFormat[$i], $html);
+            }
             return $html;
         }
         // remove empty lines


### PR DESCRIPTION
First of all, thank you for this great extension.

I encountered a strange bug there all the JS and CSS was missing from a page.
This only happens under certain circumstances.

We have a huge data attribute in our output. It holds over 3MB of JSON.

With that, the preg_split in line 189 returns false.
https://github.com/lochmueller/sourceopt/blob/master/Classes/Service/CleanHtmlService.php#L189

And there is the problem, the JS and CSS was removed from $html and is not added back to the return in line 197.
https://github.com/lochmueller/sourceopt/blob/master/Classes/Service/CleanHtmlService.php#L197