### PR TITLE
Cast tabSize to integer

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -68,7 +68,7 @@ class CleanHtmlService implements SingletonInterface
             }
 
             if ($config['formatHtml.']['tabSize'] && is_numeric($config['formatHtml.']['tabSize'])) {
-                $this->tab = str_pad('', $config['formatHtml.']['tabSize'], ' ');
+                $this->tab = str_pad('', (int) $config['formatHtml.']['tabSize'], ' ');
             }
 
             if (isset($config['formatHtml.']['debugComment'])) {


### PR DESCRIPTION
This prevents frontend error "str_pad() expects parameter 2 to be int, string given"