### PR TITLE
[FIX] viewBox extraction & inline stacked <svg>

### DIFF
--- a/Classes/Service/SvgStoreService.php
+++ b/Classes/Service/SvgStoreService.php
@@ -105,7 +105,7 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
         $svg = preg_replace('/^.*?<svg|\s*(<\/svg>)(?!.+\1).*$|xlink:|\s(?:(?:version|xmlns)|(?:[a-z\-]+\:[a-z\-]+))="[^"]*"/s', '', $svg); // cleanup
 
         // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#attributes
-        $svg = preg_replace_callback('/([^>]+)\s*(?=>)/s', function (array $match) use (&$attr): string {
+        $svg = preg_replace_callback('/([^>]*)\s*(?=>)/s', function (array $match) use (&$attr): string {
             if (false === preg_match_all('/(?!\s)(?<attr>[\w\-]+)="\s*(?<value>[^"]+)\s*"/', $match[1], $matches)) {
                 return $match[0];
             }

--- a/Classes/Service/SvgStoreService.php
+++ b/Classes/Service/SvgStoreService.php
@@ -118,7 +118,9 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
                       break;
 
                   case 'viewBox':
-                      $attr[] = sprintf('%s="%s"', $attribute, $matches['value'][$index]); // save!
+                      if (false !== preg_match('/\S+\s\S+\s\+?(?<width>[\d\.]+)\s\+?(?<height>[\d\.]+)/', $matches['value'][$index], $match)) {
+                          $attr[] = sprintf('%s="0 0 %s %s"', $attribute, $match['width'], $match['height']); // save!
+                      }
                 }
             }
 

--- a/Classes/Service/SvgStoreService.php
+++ b/Classes/Service/SvgStoreService.php
@@ -102,7 +102,7 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
         //}, $svg);
 
         // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
-        $svg = preg_replace('/.*<svg|<\/svg>.*|xlink:|\s(?:(?:version|xmlns)|(?:[a-z\-]+\:[a-z\-]+))="[^"]*"/s', '', $svg); // cleanup
+        $svg = preg_replace('/^.*?<svg|\s*(<\/svg>)(?!.+\1).*$|xlink:|\s(?:(?:version|xmlns)|(?:[a-z\-]+\:[a-z\-]+))="[^"]*"/s', '', $svg); // cleanup
 
         // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#attributes
         $svg = preg_replace_callback('/([^>]+)\s*(?=>)/s', function (array $match) use (&$attr): string {


### PR DESCRIPTION
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -300 100 100">
```
results in double downwards shift ; -300 + -300
```
<svg xmlns="http://www.w3.org/2000/svg">
  <svg viewBox="0 0 8 8">[..]
  <svg viewBox="0 0 20000 738">[..]
```
broken; mybee via fallback `viewBox="0 0 1 1"` ?