### PR TITLE
[BUGFIX] if svg doesnt exist an error is thrown

### DIFF
--- a/Classes/Service/SvgStoreService.php
+++ b/Classes/Service/SvgStoreService.php
@@ -77,6 +77,10 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
 
     private function addFileToSpriteArr(string $hash, string $path): ?array
     {
+        if (!file_exists($this->sitePath.$path)) {
+            return null;
+        }
+        
         if (1 === preg_match('/(?:;base64|i:a?i?pgf)/', $svg = file_get_contents($this->sitePath.$path))) { // noop!
             return null;
         }


### PR DESCRIPTION
on php8 there is an error if the svg file doesn't exists

`preg_match(): Argument #2 ($subject) must be of type string, bool given`

