### PR TITLE
[FIX] missing parentheses on condition break the logic

### DIFF
--- a/Classes/Middleware/CleanHtmlMiddleware.php
+++ b/Classes/Middleware/CleanHtmlMiddleware.php
@@ -38,7 +38,7 @@ class CleanHtmlMiddleware implements MiddlewareInterface
 
         if (!($response instanceof NullResponse)
         && $GLOBALS['TSFE'] instanceof TypoScriptFrontendController
-        && $GLOBALS['TSFE']->config['config']['sourceopt.']['enabled'] ?? false
+        && ($GLOBALS['TSFE']->config['config']['sourceopt.']['enabled'] ?? false)
         && 'text/html' == substr($response->getHeaderLine('Content-Type'), 0, 9)
         ) {
             $processedHtml = $this->cleanHtmlService->clean(

--- a/Classes/Middleware/SvgStoreMiddleware.php
+++ b/Classes/Middleware/SvgStoreMiddleware.php
@@ -27,7 +27,7 @@ class SvgStoreMiddleware implements MiddlewareInterface
 
         if (!($response instanceof NullResponse)
         && $GLOBALS['TSFE'] instanceof TypoScriptFrontendController
-        && $GLOBALS['TSFE']->config['config']['svgstore.']['enabled'] ?? false
+        && ($GLOBALS['TSFE']->config['config']['svgstore.']['enabled'] ?? false)
         && 'text/html' == substr($response->getHeaderLine('Content-Type'), 0, 9)
         ) {
             $processedHtml = GeneralUtility::makeInstance(\HTML\Sourceopt\Service\SvgStoreService::class)


### PR DESCRIPTION
I got the problem on a page where 'Content-Type' was `text/plain`. The if-condition evaluated to `true` instead of `false` due to the missing parentheses which lead to the output being processed by mistake.