### PR TITLE
[FIX] avoid exception in `formatHtml()` by explicit type casting

### DIFF
--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -169,7 +169,7 @@ class CleanHtmlService implements SingletonInterface
         // Save original formated pre, textarea, comments, styles and scripts & replace them with markers
         preg_match_all(
             '/(?s)((<!--.*?-->)|(<[ \n\r]*pre[^>]*>.*?<[ \n\r]*\/pre[^>]*>)|(<[ \n\r]*textarea[^>]*>.*?<[ \n\r]*\/textarea[^>]*>)|(<[ \n\r]*style[^>]*>.*?<[ \n\r]*\/style[^>]*>)|(<[ \n\r]*script[^>]*>.*?<[ \n\r]*\/script[^>]*>))/im',
-            $html,
+            (string)$html,
             $matches
         );
         $noFormat = $matches[0]; // do not format these block elements


### PR DESCRIPTION
Hey there,
as the annotation of the function `formatHtml()` says, variable `$html` should be a string. In case this is not a string, `preg_match_all` will throw an exception as it awaits second parameter to be a string.

In lines 123 and 129 this variable is being set by `preg_replace()` return value which may be `null` in case of an error. I'd like to discuss how to proceed in cases like that as my solution is not the cleanest one ...