### PR TITLE
[FIX] workflows/Release

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,8 +1,9 @@
-name: publish
+name: Release
 
 on:
   push:
-    tag:
+    tags:
+      - '*'
 
 jobs:
   publish:


### PR DESCRIPTION
are you planing to adapt https://github.com/lochmueller/staticfilecache/blob/master/.github/workflows/Release.yml ?
seems like [TER](https://extensions.typo3.org/extension/sourceopt#version-history) is not "feed" anymore