### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Resource/SvgFileRepository.php
+++ b/Classes/Resource/SvgFileRepository.php
@@ -34,15 +34,15 @@ class SvgFileRepository extends \TYPO3\CMS\Core\Resource\FileRepository
                 ->where(
                     $queryBuilder->expr()->in(
                         'sys_file.storage',
-                        $queryBuilder->createNamedParameter($storageUids, \Doctrine\DBAL\Connection::PARAM_INT_ARRAY)
+                        $queryBuilder->createNamedParameter($storageUids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
                     ),
                     $queryBuilder->expr()->lt(
                         'sys_file.size',
-                        $queryBuilder->createNamedParameter((int) $GLOBALS['TSFE']->config['config']['svgstore.']['fileSize'] ?? null, \PDO::PARAM_INT)
+                        $queryBuilder->createNamedParameter((int) $GLOBALS['TSFE']->config['config']['svgstore.']['fileSize'] ?? null, \TYPO3\CMS\Core\Database\Connection::PARAM_INT)
                     ),
                     $queryBuilder->expr()->eq(
                         'sys_file.mime_type',
-                        $queryBuilder->createNamedParameter('image/svg+xml', \PDO::PARAM_STR)
+                        $queryBuilder->createNamedParameter('image/svg+xml', \TYPO3\CMS\Core\Database\Connection::PARAM_STR)
                     )
                 )
                 ->groupBy('sys_file.uid', 'sys_file.storage', 'sys_file.identifier', 'sys_file.sha1')


### PR DESCRIPTION
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.