### PR TITLE
Fix site set constant names

### DIFF
--- a/Configuration/Sets/SourceOpt/settings.definitions.yaml
+++ b/Configuration/Sets/SourceOpt/settings.definitions.yaml
@@ -12,32 +12,32 @@ categories:
     parent: sourceopt
 
 settings:
-  plugin.sourceopt.enabled:
+  sourceopt.enabled:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.enabled
     default: true
     type: bool
     category: sourceopt.cleaner
-  plugin.sourceopt.removeGenerator:
+  sourceopt.removeGenerator:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.removeGenerator
     default: true
     type: bool
     category: sourceopt.cleaner
-  plugin.sourceopt.removeComments:
+  sourceopt.removeComments:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.removeComments
     default: true
     type: bool
     category: sourceopt.cleaner
-  plugin.sourceopt.removeComments.keep.10:
+  sourceopt.removeComments.keep.10:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.removeCommentsKeep10
     default: '/^TYPO3SEARCH_/usi'
     type: string
     category: sourceopt.cleaner
-  plugin.sourceopt.headerComment:
+  sourceopt.headerComment:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.headerComment
     default: ''
     type: string
     category: sourceopt.cleaner
-  plugin.sourceopt.formatHtml:
+  sourceopt.formatHtml:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.formatHtml
     default: '4'
     type: string
@@ -48,22 +48,22 @@ settings:
   #      '2': Minimalistic line breaks (structure defining box-elements)
   #      '3': Aesthetic line breaks (important box-elements)
   #      '4': Logic line breaks (all box-elements)
-  plugin.sourceopt.formatHtml.tabSize:
+  sourceopt.formatHtml.tabSize:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.formatHtmlTabSize
     default: ''
     type: string
     category: sourceopt.formater
-  plugin.sourceopt.formatHtml.debugComment:
+  sourceopt.formatHtml.debugComment:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:sourceopt.formatHtmlDebugComment
     default: false
     type: bool
     category: sourceopt.formater
-  plugin.svgstore.enabled:
+  svgstore.enabled:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:svgstore.enabled
     default: true
     type: bool
     category: sourceopt.svgstore
-  plugin.svgstore.fileSize:
+  svgstore.fileSize:
     label: LLL:EXT:sourceopt/Resources/Private/Language/locallang.xlf:svgstore.fileSize
     default: 50000
     type: int


### PR DESCRIPTION
The constant names in the provided site do not match the used constant names that are used in the TypoScript setup.

So if someone tries to use this extension in TYPO3 >= v13 by depending on its site set, it won't work right now, as e.g. `plugin.svgstore.enabled` won't match `{$svgstore.enabled}`.

There are two possible solutions/ fixes for this problem:

1. by renaming/ removing the `plugin.` prefix for all constants in the provided site set `settings.definitions.yaml`
2. by checking both variables/ constants in the provided TypoScript setup, 
    - e.g. 
    ```
    ...
    config.svgstore {
        enabled = {$svgstore.enabled ?? $plugin.svgstore.enabled}
        fileSize = {$svgstore.fileSize ?? plugin.svgstore.fileSize}
    }
    ...
    ```

This PR fixes the problem with the first solution, removing the `plugin.` prefix in the `settings.definitions.yaml`, as this IMHO should be the "cleaner" solution. Nevertheless, this will introduce a "BREAKING CHANGE".

The second solution would cover both constant versions, but adds IMHO unnecessary "overhead".

Right now, using the extension only via site set dependency in a "site package" extension, won't work out of the box and I think most people "fixed" it by using/importing the classic TypoScript constants instead of the provided site set.

