### PR TITLE
TYPO3 14 support

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -9,40 +9,44 @@ jobs:
   publish:
     name: Publish new version to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check tag
         run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             exit 1
           fi
       - name: Get version
         id: get-version
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ steps.get-version.outputs.version }} | sed "s/^[0-9.]*[ ]*//g")
+          comment=$(git tag -n10 -l "${{ steps.get-version.outputs.version }}" | sed "s/^[0-9.]*[ ]*//g")
           if [[ -z "${comment// }" ]]; then
-            echo ::set-output name=comment::Released version ${{ steps.get-version.outputs.version }} of sourceopt
-          else
-            echo ::set-output name=comment::$comment
+            comment="Released version ${{ steps.get-version.outputs.version }} of sourceopt"
           fi
+          {
+            echo "comment<<TAG_COMMENT"
+            echo "$comment"
+            echo "TAG_COMMENT"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.2
           extensions: intl, mbstring, json, zip, curl
 
       - name: Install tailor
-        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+        run: composer global require typo3/tailor --prefer-dist --no-progress
 
       - name: Publish to TER
         run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ steps.get-comment.outputs.comment }}" ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -7,14 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        typo3: [12.4, 13.4]
-        php: [8.1, 8.2, 8.3]
-        exclude:
-          - php: "8.1"
-            typo3: "13.4"
+        typo3: [13.4, 14.3]
+        php: [8.2, 8.3, 8.4]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,12 +31,12 @@ jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer
 
       - name: Install requirements
@@ -51,12 +48,12 @@ jobs:
   messdetector:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer
 
       - name: Install requirements

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.idea/
 /.Build/*
 /var/
-/Tests/.phpunit.result.cache
+/Tests/.phpunit.cache/
 /composer.lock

--- a/Classes/Middleware/AbstractMiddleware.php
+++ b/Classes/Middleware/AbstractMiddleware.php
@@ -5,21 +5,17 @@ declare(strict_types=1);
 namespace HTML\Sourceopt\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use TYPO3\CMS\Core\Http\NullResponse;
 use TYPO3\CMS\Core\Http\Stream;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 abstract class AbstractMiddleware implements MiddlewareInterface
 {
     protected function responseIsAlterable(ResponseInterface $response): bool
     {
         if ($response instanceof NullResponse) {
-            return false;
-        }
-
-        if (!$GLOBALS['TSFE'] instanceof TypoScriptFrontendController) { // need for configuration
             return false;
         }
 
@@ -32,6 +28,14 @@ abstract class AbstractMiddleware implements MiddlewareInterface
         }
 
         return true;
+    }
+
+    /**
+     * TypoScript "config." of the current page; empty outside a rendered frontend.
+     */
+    protected function getTypoScriptConfig(ServerRequestInterface $request): array
+    {
+        return $request->getAttribute('frontend.typoscript')?->getConfigArray() ?? [];
     }
 
     protected function getStringStream(string $content): StreamInterface

--- a/Classes/Middleware/CleanHtmlMiddleware.php
+++ b/Classes/Middleware/CleanHtmlMiddleware.php
@@ -18,12 +18,14 @@ class CleanHtmlMiddleware extends AbstractMiddleware
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
+        $config = $this->getTypoScriptConfig($request);
 
-        if ($this->responseIsAlterable($response) && ($GLOBALS['TSFE']->config['config']['sourceopt.']['enabled'] ?? false)) {
+        if ($this->responseIsAlterable($response) && ($config['sourceopt.']['enabled'] ?? false)) {
             $cleanHtmlService = GeneralUtility::makeInstance(CleanHtmlService::class);
             $processedHtml = $cleanHtmlService->clean(
                 (string) $response->getBody(),
-                (array) $GLOBALS['TSFE']->config['config']['sourceopt.']
+                (array) $config['sourceopt.'],
+                (string) ($config['doctype'] ?? '')
             );
             $response = $response->withBody($this->getStringStream($processedHtml));
         }

--- a/Classes/Middleware/RegExRepMiddleware.php
+++ b/Classes/Middleware/RegExRepMiddleware.php
@@ -18,10 +18,11 @@ class RegExRepMiddleware extends AbstractMiddleware
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
+        $config = $this->getTypoScriptConfig($request);
 
-        if ($this->responseIsAlterable($response) && ($GLOBALS['TSFE']->config['config']['replacer.'] ?? false)) {
+        if ($this->responseIsAlterable($response) && ($config['replacer.'] ?? false)) {
             $regExRepService = GeneralUtility::makeInstance(RegExRepService::class);
-            $processedHtml = $regExRepService->process((string) $response->getBody());
+            $processedHtml = $regExRepService->process((string) $response->getBody(), (array) $config['replacer.'], $request);
             $response = $response->withBody($this->getStringStream($processedHtml));
         }
 

--- a/Classes/Middleware/SvgStoreMiddleware.php
+++ b/Classes/Middleware/SvgStoreMiddleware.php
@@ -18,10 +18,11 @@ class SvgStoreMiddleware extends AbstractMiddleware
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
+        $config = $this->getTypoScriptConfig($request);
 
-        if ($this->responseIsAlterable($response) && ($GLOBALS['TSFE']->config['config']['svgstore.']['enabled'] ?? false)) {
+        if ($this->responseIsAlterable($response) && ($config['svgstore.']['enabled'] ?? false)) {
             $svgStoreService = GeneralUtility::makeInstance(SvgStoreService::class);
-            $processedHtml = $svgStoreService->process((string) $response->getBody());
+            $processedHtml = $svgStoreService->process((string) $response->getBody(), $config);
             $response = $response->withBody($this->getStringStream($processedHtml));
         }
 

--- a/Classes/Resource/SvgFileRepository.php
+++ b/Classes/Resource/SvgFileRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HTML\Sourceopt\Resource;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -16,8 +17,10 @@ class SvgFileRepository
 {
     /**
      * Retrieves all used SVGs within given storage-array.
+     *
+     * @param int $maxFileSize TypoScript "config.svgstore.fileSize" of the current page
      */
-    public function findAllByStorageUids(array $storageUids): \Traversable
+    public function findAllByStorageUids(array $storageUids, int $maxFileSize): \Traversable
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_file');
 
@@ -36,15 +39,15 @@ class SvgFileRepository
             ->where(
                 $queryBuilder->expr()->in(
                     'sys_file.storage',
-                    $queryBuilder->createNamedParameter($storageUids, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
+                    $queryBuilder->createNamedParameter($storageUids, Connection::PARAM_INT_ARRAY)
                 ),
                 $queryBuilder->expr()->lt(
                     'sys_file.size',
-                    $queryBuilder->createNamedParameter((int) ($GLOBALS['TSFE']->config['config']['svgstore.']['fileSize'] ?? null), \TYPO3\CMS\Core\Database\Connection::PARAM_INT)
+                    $queryBuilder->createNamedParameter($maxFileSize, Connection::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq(
                     'sys_file.mime_type',
-                    $queryBuilder->createNamedParameter('image/svg+xml', \TYPO3\CMS\Core\Database\Connection::PARAM_STR)
+                    $queryBuilder->createNamedParameter('image/svg+xml', Connection::PARAM_STR)
                 )
             )
             ->groupBy('sys_file.uid', 'sys_file.storage', 'sys_file.identifier', 'sys_file.sha1')

--- a/Classes/Service/CleanHtmlService.php
+++ b/Classes/Service/CleanHtmlService.php
@@ -92,8 +92,10 @@ class CleanHtmlService implements SingletonInterface
 
     /**
      * Clean given HTML with formatter.
+     *
+     * @param string $doctype TypoScript "config.doctype" of the current page
      */
-    public function clean(string $html, array $config = []): string
+    public function clean(string $html, array $config = [], string $doctype = ''): string
     {
         if (!mb_check_encoding($html, 'UTF-8')) {
             throw new \Exception('Invalid UTF-8 detected @ ' . $this->getInvalidUTF8Snipped($html));
@@ -128,8 +130,7 @@ class CleanHtmlService implements SingletonInterface
         }
 
         // cleanup HTML5 self-closing elements
-        if (!isset($GLOBALS['TSFE']->config['config']['doctype'])
-            || 'x' !== substr($GLOBALS['TSFE']->config['config']['doctype'], 0, 1)) {
+        if ('x' !== substr($doctype, 0, 1)) {
             $html = preg_replace(
                 '/<((?:area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\s[^>]+?)\s*\\\?\/>/',
                 '<$1>',

--- a/Classes/Service/RegExRepService.php
+++ b/Classes/Service/RegExRepService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HTML\Sourceopt\Service;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -16,17 +17,18 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class RegExRepService implements SingletonInterface
 {
-    public function process(string $html): string
+    /**
+     * @param array $config TypoScript "config.replacer." of the current page
+     */
+    public function process(string $html, array $config, ServerRequestInterface $request): string
     {
-        $config = $GLOBALS['TSFE']->config['config']['replacer.'];
-
         foreach (['search.', 'replace.'] as $section) {
             if (!isset($config[$section]) || !\is_array($config[$section])) {
                 throw new \Exception('missing entry @ config.replacer.' . $section);
             }
 
             if (preg_match_all('/"([\w\-]+)\.";/', serialize(array_keys($config[$section])), $matches)) {
-                $cObj ??= ($GLOBALS['TSFE']->cObj ?? GeneralUtility::makeInstance(ContentObjectRenderer::class));
+                $cObj ??= $this->createContentObjectRenderer($request);
 
                 foreach ($matches[1] as $key) {
                     $config[$section][$key] = $cObj
@@ -57,5 +59,16 @@ class RegExRepService implements SingletonInterface
         }
 
         return preg_replace($config['search.'], $config['replace.'], $html);
+    }
+
+    /**
+     * The middleware runs outside content rendering, so there is no cObj to reuse.
+     */
+    private function createContentObjectRenderer(ServerRequestInterface $request): ContentObjectRenderer
+    {
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj->setRequest($request);
+
+        return $cObj;
     }
 }

--- a/Classes/Service/SvgStoreService.php
+++ b/Classes/Service/SvgStoreService.php
@@ -53,38 +53,41 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected array $defs = []; // Fix'd ? https://github.com/chromium/chromium/commit/4f3ebd119d5c8492fa8564d61d8b600a82e4a041
 
-    protected function init()
+    protected function init(array $config)
     {
         static $alreadyLoaded = false;
 
         if ($alreadyLoaded) {
             return;
         }
-        
+
         $this->sitePath = Environment::getPublicPath(); // [^/]$
 
         $this->spritePath = $this->getCache()->get('spritePath') ?: '';
         $this->svgFileArr = $this->getCache()->get('svgFileArr') ?: [];
 
-        if (empty($this->spritePath) && !$this->populateCache()) {
+        if (empty($this->spritePath) && !$this->populateCache($config)) {
             throw new \Exception('could not write file: ' . $this->sitePath . $this->spritePath);
         }
 
         if (!file_exists($this->sitePath . $this->spritePath)) {
             throw new \Exception('file does not exists: ' . $this->sitePath . $this->spritePath);
         }
-        
+
         $alreadyLoaded = true;
     }
 
-    public function process(string $html): string
+    /**
+     * @param array $config TypoScript "config." of the current page
+     */
+    public function process(string $html, array $config): string
     {
-        $this->init();
+        $this->init($config);
         if (empty($this->svgFileArr)) {
             return $html;
         }
 
-        if ($GLOBALS['TSFE']->config['config']['disableAllHeaderCode'] ?? false) {
+        if ($config['disableAllHeaderCode'] ?? false) {
             $dom = ['head' => '', 'body' => $html];
         } elseif (!preg_match('/(?<head>.+?<\/head>)(?<body>.+)/s', $html, $dom)) {
             return $html;
@@ -185,7 +188,7 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
         return ['attr' => implode(' ', $attr), 'hash' => $hash];
     }
 
-    private function populateCache(): bool
+    private function populateCache(array $config): bool
     {
         $storageArr = GeneralUtility::makeInstance(StorageRepository::class)->findByStorageType('Local');
         foreach ($storageArr as $storage) {
@@ -199,7 +202,10 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
         }
         unset($storageArr[0]); // keep!
 
-        $fileArr = GeneralUtility::makeInstance(SvgFileRepository::class)->findAllByStorageUids(array_keys($storageArr));
+        $fileArr = GeneralUtility::makeInstance(SvgFileRepository::class)->findAllByStorageUids(
+            array_keys($storageArr),
+            (int) ($config['svgstore.']['fileSize'] ?? 0)
+        );
         foreach ($fileArr as $file) {
             $file['path'] = '/' . $storageArr[$file['storage']] . $file['identifier']; // ^[/]
             $file['defs'] = $this->addFileToSpriteArr($file['sha1'], $file['path']);
@@ -229,7 +235,7 @@ class SvgStoreService implements \TYPO3\CMS\Core\SingletonInterface
             . '</svg>'
         );
 
-        if ($GLOBALS['TSFE']->config['config']['sourceopt.']['formatHtml'] ?? false) {
+        if ($config['sourceopt.']['formatHtml'] ?? false) {
             $svg = preg_replace('/(?<=>)\s+(?=<)/', '', $svg); // remove emptiness
             $svg = preg_replace('/[\t\v]/', ' ', $svg); // prepare shrinkage
             $svg = preg_replace('/\s{2,}/', ' ', $svg); // shrink whitespace

--- a/Resources/Private/Build/PhpCsFixer.php
+++ b/Resources/Private/Build/PhpCsFixer.php
@@ -18,7 +18,7 @@ return (new PhpCsFixer\Config())
         '@PER-CS2.0:risky' => true,
         '@DoctrineAnnotation' => true,
         '@PSR2' => true,
-        '@PHP81Migration' => true,
+        '@PHP82Migration' => true,
         'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder($finder)

--- a/Tests/Unit/Manipulation/RemoveCommentTest.php
+++ b/Tests/Unit/Manipulation/RemoveCommentTest.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace HTML\Sourceopt\Tests\Unit\Service;
+namespace HTML\Sourceopt\Tests\Unit\Manipulation;
 
 use HTML\Sourceopt\Manipulation\RemoveComments;
 use HTML\Sourceopt\Tests\Unit\AbstractUnitTest;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class RemoveCommentTest extends AbstractUnitTest
 {
-    /**
-     * @dataProvider generatorProvider
-     */
-    public function testRemoveComment($before, $after): void
+    #[DataProvider('generatorProvider')]
+    public function testRemoveComment(string $before, string $after): void
     {
         $cleanService = new RemoveComments();
         $result = $cleanService->manipulate($before);
 
-        $this->assertEquals($after, $result);
+        self::assertSame($after, $result);
     }
 
     public static function generatorProvider(): array
@@ -53,6 +52,31 @@ class RemoveCommentTest extends AbstractUnitTest
 <meta name="generator" content="Tester">
 
 </head>',
+            ],
+        ];
+    }
+
+    #[DataProvider('keepProvider')]
+    public function testKeepsWhiteListedComments(array $keep, string $before, string $after): void
+    {
+        $cleanService = new RemoveComments();
+        $result = $cleanService->manipulate($before, ['keep.' => $keep]);
+
+        self::assertSame($after, $result);
+    }
+
+    public static function keepProvider(): array
+    {
+        return [
+            'pattern matches' => [
+                ['/^TYPO3SEARCH_/usi'],
+                '<div><!--TYPO3SEARCH_begin--><!-- Ich bin ein Test --></div>',
+                '<div><!--TYPO3SEARCH_begin--></div>',
+            ],
+            'pattern does not match' => [
+                ['/^SOMETHING_ELSE/usi'],
+                '<div><!--TYPO3SEARCH_begin--></div>',
+                '<div></div>',
             ],
         ];
     }

--- a/Tests/Unit/Manipulation/RemoveGeneratorTest.php
+++ b/Tests/Unit/Manipulation/RemoveGeneratorTest.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace HTML\Sourceopt\Tests\Unit\Service;
+namespace HTML\Sourceopt\Tests\Unit\Manipulation;
 
 use HTML\Sourceopt\Manipulation\RemoveGenerator;
 use HTML\Sourceopt\Tests\Unit\AbstractUnitTest;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class RemoveGeneratorTest extends AbstractUnitTest
 {
-    /**
-     * @dataProvider generatorProvider
-     */
-    public function testRemoveGenerator($before, $after): void
+    #[DataProvider('generatorProvider')]
+    public function testRemoveGenerator(string $before, string $after): void
     {
         $cleanService = new RemoveGenerator();
         $result = $cleanService->manipulate($before);
 
-        $this->assertEquals($after, $result);
+        self::assertSame($after, $result);
     }
 
     public static function generatorProvider(): array

--- a/Tests/Unit/Service/CleanHtmlServiceTest.php
+++ b/Tests/Unit/Service/CleanHtmlServiceTest.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace HTML\Sourceopt\Service;
+namespace HTML\Sourceopt\Tests\Unit\Service;
 
+use HTML\Sourceopt\Service\CleanHtmlService;
 use HTML\Sourceopt\Tests\Unit\AbstractUnitTest;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class CleanHtmlServiceTest extends AbstractUnitTest
 {
     public function testFormatHtml(): void
     {
-        $this->markTestSkipped();
-
-        $clean = new CleanHtmlService();
+        $cleanService = new CleanHtmlService();
         $config = [
             'enabled' => true,
             'removeComments' => true,
@@ -40,7 +40,41 @@ class CleanHtmlServiceTest extends AbstractUnitTest
     </path>
   </path>
 </svg>';
-        $result = $clean->clean($svg, $config);
-        $this->assertEquals($svg, $result);
+
+        self::assertSame($svg, $cleanService->clean($svg, $config));
+    }
+
+    /**
+     * The doctype used to come from $GLOBALS['TSFE'], it is now passed in.
+     */
+    #[DataProvider('doctypeProvider')]
+    public function testSelfClosingTagsDependOnDoctype(string $doctype, string $expected): void
+    {
+        $cleanService = new CleanHtmlService();
+        $html = '<head><meta name="viewport" content="width=device-width" /></head>';
+
+        self::assertSame($expected, $cleanService->clean($html, ['formatHtml' => 0], $doctype));
+    }
+
+    public static function doctypeProvider(): array
+    {
+        return [
+            'html5 drops the self-closing slash' => [
+                '',
+                '<head><meta name="viewport" content="width=device-width"></head>',
+            ],
+            'xhtml keeps it' => [
+                'xhtml',
+                '<head><meta name="viewport" content="width=device-width" /></head>',
+            ],
+        ];
+    }
+
+    public function testInvalidUtf8IsRejected(): void
+    {
+        $cleanService = new CleanHtmlService();
+
+        $this->expectException(\Exception::class);
+        $cleanService->clean("<head>\xC3\x28</head>");
     }
 }

--- a/Tests/UnitTests.xml
+++ b/Tests/UnitTests.xml
@@ -1,22 +1,29 @@
-<phpunit
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
 		backupGlobals="true"
-		backupStaticAttributes="false"
 		bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+		cacheDirectory=".phpunit.cache"
+		cacheResult="false"
 		colors="true"
-		convertErrorsToExceptions="true"
-		convertWarningsToExceptions="true"
-		forceCoversAnnotation="false"
-		processIsolation="false"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="false"
+		displayDetailsOnTestsThatTriggerDeprecations="true"
+		displayDetailsOnTestsThatTriggerErrors="true"
+		displayDetailsOnTestsThatTriggerNotices="true"
+		displayDetailsOnTestsThatTriggerWarnings="true"
+		failOnDeprecation="true"
+		failOnNotice="true"
+		failOnRisky="true"
+		failOnWarning="true"
+		requireCoverageMetadata="false"
 >
 	<testsuites>
 		<testsuite name="sourceopt tests">
 			<directory>Unit/</directory>
-            <exclude>./Unit/AbstractUnitTest.php</exclude>
+			<exclude>./Unit/AbstractUnitTest.php</exclude>
 		</testsuite>
 	</testsuites>
+	<php>
+		<ini name="display_errors" value="1"/>
+		<env name="TYPO3_CONTEXT" value="Testing"/>
+	</php>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
 	"homepage": "https://github.com/lochmueller/sourceopt",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": "^8.1",
-		"typo3/cms-core": "^12.4||^13.4",
+		"php": "^8.2",
+		"typo3/cms-core": "^13.4||^14.3",
 		"schleuse/dindent": "^3.0"
 	},
 	"autoload": {
@@ -15,7 +15,7 @@
 		}
 	},
 	"require-dev": {
-		"typo3/testing-framework": "^8.2",
+		"typo3/testing-framework": "^9.0",
 		"friendsofphp/php-cs-fixer": "^3.3",
 		"phpmd/phpmd": "^2.10"
 	},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,8 +11,8 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => null,
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
-            'php' => '8.1.0-8.99.99',
+            'typo3' => '13.4.0-14.99.99',
+            'php' => '8.2.0-8.99.99',
         ],
     ],
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,4 +1,4 @@
-<?php defined('TYPO3_MODE') || defined('TYPO3') || die();
+<?php defined('TYPO3') || die();
 
 // SvgStore Cache
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['svgstore'])) {


### PR DESCRIPTION
This PR adds TYPO3 14.3 support and addresses #169 in the process.

There have been some major changes in TYPO3 14.3 - i.e. `TypoScriptFrontendController` has been removed. Furthermore the support for TYPO3 12.4 already ended a while ago. That's why the most sensible thing to do was, to remove the compatibility to TYPO3 12.4 but staying in the 2-version cycle and now supporting TYPO3 13.4 and 14.3 instead.

This is a breaking change. So it would need a new major version. Therefore I suggest a new release version 6.0.0 once the PR has been accepted. Some more prerequisites for a new release would be to adjust the README.md with respective compatibility instructions accordingly.

If something feels off, I'm happy to address any issues right away. I'm off duty at the moment and had the time to update EXT:sourceopt while relaunching a website of a friend of mine. For what it's worth, I can assure that the extension works exactly like it is supposed to and nowhere different from before.

For any elaborate questions or further discussions, we can also connect on Slack.